### PR TITLE
Fix symptom persistence and improve GraphQL query handling

### DIFF
--- a/client/patient-app/package-lock.json
+++ b/client/patient-app/package-lock.json
@@ -12,6 +12,7 @@
         "@originjs/vite-plugin-federation": "^1.4.0",
         "bootstrap": "^5.3.5",
         "date-fns": "^4.1.0",
+        "jwt-decode": "^4.0.0",
         "react": "^19.0.0",
         "react-bootstrap": "^2.10.9",
         "react-dom": "^19.0.0",
@@ -2513,6 +2514,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/client/patient-app/package.json
+++ b/client/patient-app/package.json
@@ -15,6 +15,7 @@
     "@originjs/vite-plugin-federation": "^1.4.0",
     "bootstrap": "^5.3.5",
     "date-fns": "^4.1.0",
+    "jwt-decode": "^4.0.0",
     "react": "^19.0.0",
     "react-bootstrap": "^2.10.9",
     "react-dom": "^19.0.0",

--- a/server/patient-microservice/app/resolvers/patient.resolver.js
+++ b/server/patient-microservice/app/resolvers/patient.resolver.js
@@ -136,7 +136,31 @@ const patientResolvers = {
         patientSymptoms: async (_, { patientId }, { user }) => {
             ensureAuthenticated(user);
             const patientData = await PatientData.findOne({ user: patientId });
-            if (!patientData) return null;
+            if (!patientData) {
+                // Return default symptoms if patient data doesn't exist
+                return {
+                    breathingProblem: false,
+                    fever: false,
+                    dryCough: false,
+                    soreThroat: false,
+                    runningNose: false,
+                    asthma: false,
+                    chronicLungDisease: false,
+                    headache: false,
+                    heartDisease: false,
+                    diabetes: false,
+                    hyperTension: false,
+                    fatigue: false,
+                    gastrointestinal: false,
+                    abroadTravel: false,
+                    contactWithCovidPatient: false,
+                    attendedLargeGathering: false,
+                    visitedPublicExposedPlaces: false,
+                    familyWorkingInPublicExposedPlaces: false,
+                    wearingMasks: false,
+                    sanitizationFromMarket: false
+                };
+            }
             // Only allow access if user is a nurse or the patient themselves.
             if (user.role !== 'NURSE' && user.id !== patientId) {
                 throw new GraphQLError('Not authorized to view this patient\'s symptoms');
@@ -227,9 +251,13 @@ const patientResolvers = {
             ensurePatientAuthenticated(user);
             let patientData = await PatientData.findOne({ user: user.id });
             if (!patientData) {
-                patientData = new PatientData({ user: user.id });
+                // Create new patient data with default symptoms
+                patientData = new PatientData({ 
+                    user: user.id,
+                    symptoms: {} // This will be initialized with default values from the schema
+                });
             }
-            // Update the symptoms field with the provided checklist.
+            // Update the symptoms field with the provided checklist
             patientData.symptoms = { ...symptoms };
             await patientData.save();
             return patientData.symptoms;


### PR DESCRIPTION
1. Installed jwt-decode and updated the SymptomsList component, the changes should fix the issues:
- The component now gets the user ID from the authentication token instead of expecting it as a prop
- The GraphQL query will only run when we have a valid user ID
- We're using cache-and-network fetch policy for better performance while ensuring data is fresh

2. Changed in patient.resolver.js:
- Provide better error handling
- Ensure consistent data structure
- Handle the case of new patients properly
- Follow best practices for data initialization
- The changes in the resolver help prevent null/undefined errors and ensure that symptoms are always properly initialized and saved. This makes the frontend code more reliable since it can always expect a valid symptoms object.

3.  Removed the "Other Symptoms" field

Resolved #20 